### PR TITLE
minimize ants and fsl installations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.tar.gz
+script_test_data-master
+slim-installs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.tar.gz
+script_test_data-master
+slim-installs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,73 +1,82 @@
-FROM neurodebian:nd18.04-non-free
+ARG MAKE_JOBS="1"
+ARG DEBIAN_FRONTEND="noninteractive"
 
+FROM buildpack-deps:buster AS base-builder
+
+FROM base-builder AS mrtrix3-builder
+
+# Number of processors to use when building MRtrix3.
+ARG MAKE_JOBS
 # Git commit from which to build MRtrix3.
 ARG MRTRIX3_GIT_COMMITISH="master"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS=""
 # Command-line arguments for `./build`
 ARG MRTRIX3_BUILD_FLAGS=""
-# Temporary dependencies that can be removed after MRtrix3 build
-ARG MRTRIX3_TEMP_DEPS="g++ git libeigen3-dev"
-# Temporary dependencies for other software packages
-ARG OTHER_TEMP_DEPS="ca-certificates curl file python wget"
 
-# Prevent programs like `apt-get` from presenting interactive prompts.
-ARG DEBIAN_FRONTEND="noninteractive"
-
-ENV FREESURFER_HOME="/opt/freesurfer"
-ENV FSLDIR="/opt/fsl"
-ENV PATH="/opt/mrtrix3/bin:/opt/fsl/bin:/usr/lib/ants:$PATH"
-
-# Install MRtrix3 compile-time dependencies.
 RUN apt-get -qq update \
     && apt-get install -yq --no-install-recommends \
-          $MRTRIX3_TEMP_DEPS \
-          $OTHER_TEMP_DEPS \
-          dc \
-          libfftw3-dev \
-          libgl1-mesa-dev \
-          libpng-dev \
-          libqt5opengl5-dev \
-          libqt5svg5-dev \
-          libtiff5-dev \
-          python3 \
-          python3-distutils \
-          qt5-default \
-          zlib1g-dev
+        dc \
+        libeigen3-dev \
+        libfftw3-dev \
+        libgl1-mesa-dev \
+        libpng-dev \
+        libqt5opengl5-dev \
+        libqt5svg5-dev \
+        libtiff5-dev \
+        qt5-default \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Clone, build, and install MRtrix3.
 WORKDIR /opt/mrtrix3
 RUN git clone -b ${MRTRIX3_GIT_COMMITISH} --depth 1 https://github.com/MRtrix3/mrtrix3.git . \
     && ./configure $MRTRIX3_CONFIGURE_FLAGS \
-    && ./build $MRTRIX3_BUILD_FLAGS \
-    && apt-get remove --purge -y $MRTRIX3_TEMP_DEPS \
-    && apt-get autoremove -y
-WORKDIR /
+    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS
+RUN rm -rf tmp
 
-# Install ANTs.
-RUN apt-get -qq update \
-    && apt-get install -yq --no-install-recommends "ants=2.2.0-1ubuntu1"
+# Download ANTs.
+FROM base-builder as ants-installer
+WORKDIR /opt/ants
+RUN curl -fsSL https://dl.dropbox.com/s/fcdc9qg9jk0gbtw/ants-v0.tar.gz \
+    | tar xz --strip-components 1
 
-# Install FreeSurfer LUT
+# Download FreeSurfer files.
+FROM base-builder as freesurfer-installer
 WORKDIR /opt/freesurfer
-RUN wget -q https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
 
-# Install FSL.
-RUN wget -q http://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py -O /fslinstaller.py \
-    && chmod 775 /fslinstaller.py \
-    && python2 /fslinstaller.py -d /opt/fsl -V 6.0.4 -q \
-    && rm -f /fslinstaller.py \
-    && ( which immv || ( echo "FSLPython not properly configured; re-running" && rm -rf /opt/fsl/fslpython && /opt/fsl/etc/fslconf/fslpython_install.sh -f /opt/fsl || ( cat /tmp/fslpython*/fslpython_miniconda_installer.log && exit 1 ) ) )
+# Download FSL.
+FROM base-builder as fsl-installer
+WORKDIR /opt/fsl
+RUN curl -fsSL https://dl.dropbox.com/s/p5jftiicz43p6tt/fsl-v0.tar.gz \
+    | tar xz --strip-components 1
 
-# Do a system cleanup.
-RUN apt-get clean \
-    && apt-get remove --purge -y $OTHER_TEMP_DEPS \
-    && apt-get autoremove -y \
+# Build final image.
+FROM python:3.8-slim AS final
+
+# Install runtime system dependencies.
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        libfftw3-3 \
+        libgl1-mesa-glx \
+        libgomp1 \
+        libqt5core5a \
+        libqt5gui5 \
+        libqt5network5 \
+        libqt5widgets5 \
+        libquadmath0 \
+        libtiff5 \
     && rm -rf /var/lib/apt/lists/*
 
-# Set up to use Python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
+COPY --from=ants-installer /opt/ants /opt/ants
+COPY --from=freesurfer-installer /opt/freesurfer /opt/freesurfer
+COPY --from=fsl-installer /opt/fsl /opt/fsl
+COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3
+
+ENV FREESURFER_HOME="/opt/freesurfer" \
+    LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH" \
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/fsl/bin:$PATH"
 
 WORKDIR /work
-
-ENTRYPOINT ["bash", "-c", "source /opt/fsl/etc/fslconf/fsl.sh && bash $@"]
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,53 @@
 # Containers for MRtrix3
 
 Hosts Dockerfiles to build MRtrix3 containers
+
+## Build
+
+1. Build full Docker image, with complete ANTs and FSL installations
+
+    This step should be run very infrequently. The full image is only necessary to create the slim installations of ANTs and FSL, which are used in the slim Docker image. If mrtrix3 programs in the future require other parts of ANTs or FSL (or other software), then the full image will have to be rebuilt, and the slim installations of ANTs and FSL will have to be re-uploaded online.
+
+    ```
+    DOCKER_BUILDKIT=1 docker build --tag mrtrix3:full --file full.Dockerfile --build-arg MAKE_JOBS=2 .
+    ```
+
+    `DOCKER_BUILDKIT=1` enables BuildKit, which builds separate build stages in parallel. This can greatly speed up Docker build times. In this case, ANTs and MRtrix3 will be compiled in parallel, and FSL will be downloaded at the same time as well.
+
+    The `MAKE_JOBS` argument controls how many cores are used for compilation of ANTs and MRtrix3. Because both packages are build in parallel, do not specify all of the available cores. Specify fewer than half, so at least one core is available for downloading FSL.
+
+2. Create a minified version of the Docker image.
+
+    - Download test data
+
+    ```
+    curl -fL -# https://github.com/MRtrix3/script_test_data/archive/master.tar.gz | tar xz
+    ```
+
+    ```
+    docker run --rm -itd --name mrtrix3 --security-opt=seccomp:unconfined --volume $(pwd)/script_test_data-master:/mnt mrtrix3:full
+    neurodocker-minify --dirs-to-prune /opt --container mrtrix3 --commands "bash cmds-to-minify.sh"
+    docker export mrtrix3 | docker import - mrtrix3:minified-ants-fsl
+    docker stop mrtrix3
+    ```
+
+    - Extract `/opt/ants` and `/opt/fsl` from the image, bundle them into two `.tar.gz` files, and upload somewhere.
+
+    ```
+    mkdir -p slim-installs
+    docker run --rm -itd --workdir /opt --name mrtrix3 \
+        --volume $(pwd)/slim-installs:/output mrtrix3:minified-ants-fsl bash
+    # Install pigz for multi-core gzip compression.
+    docker exec mrtrix3 bash -c "apt-get update && apt-get install --yes pigz"
+    docker exec mrtrix3 bash -c "tar c ants | pigz -9 > /output/ants.tar.gz"
+    docker exec mrtrix3 bash -c "tar c fsl | pigz -9 > /output/fsl.tar.gz"
+    docker stop mrtrix3
+    ```
+
+3. Build Dockerfile
+
+    ```
+    DOCKER_BUILDKIT=1 docker build --tag mrtrix3:slim --file slim.Dockerfile --build-arg MAKE_JOBS=6 .
+    ```
+
+    In this Dockerfile, the only software being compiled is MRtrix3, so all (or most) CPU cores can be used for the build. The minified parts of ANTs and FSL are downloaded from the web.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 Hosts Dockerfiles to build MRtrix3 containers
 
-## Build
+## Build Docker image
+
+```
+docker build --tag mrtrix3 .
+```
+
+Set `DOCKER_BUILDKIT=1` to build parts of the Docker image in parallel and greatly speed up build time. Use `--build-arg MAKE_JOBS=4` to build MRtrix3 with 4 processors. Substitute this with any number of processors > 0.
+
+## Run GUI
+
+These instructions are for Linux.
+
+```
+xhost +local:root
+docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY mrtrix3 mrview
+xhost -local:root  # Run this when finished.
+```
+
+## Update minified ANTs and FSL installations
 
 1. Build full Docker image, with complete ANTs and FSL installations
 
@@ -44,10 +62,10 @@ Hosts Dockerfiles to build MRtrix3 containers
     docker stop mrtrix3
     ```
 
-3. Build Dockerfile
+3. Build Docker image
 
     ```
-    DOCKER_BUILDKIT=1 docker build --tag mrtrix3:slim --file slim.Dockerfile --build-arg MAKE_JOBS=6 .
+    DOCKER_BUILDKIT=1 docker build --tag mrtrix3 --build-arg MAKE_JOBS=6 .
     ```
 
     In this Dockerfile, the only software being compiled is MRtrix3, so all (or most) CPU cores can be used for the build. The minified parts of ANTs and FSL are downloaded from the web.

--- a/cmds-to-minify.sh
+++ b/cmds-to-minify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ ! -d /mnt/BIDS ]; then
+    echo "error: directory not found: /mnt/BIDS"
+    echo ""
+    echo "Be sure to mount the data directory to /mnt"
+    exit 1
+fi
+
+# Run tests to capture external software dependencies
+5ttgen fsl /mnt/BIDS/sub-01/anat/sub-01_T1w.nii.gz /tmp/5ttgen_fsl.mif -force
+rm -f /tmp/5ttgen_fsl.mif
+
+5ttgen hsvs /mnt/freesurfer/sub-01 /tmp/5ttgen_hsvs.mif -force
+rm -f /tmp/5ttgen_hsvs.mif
+
+dwibiascorrect ants /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval /tmp/dwibiascorrect_ants.mif -force
+rm -f /tmp/dwibiascorrect_ants.mif
+
+dwibiascorrect fsl /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval /tmp/dwibiascorrect_fsl.mif -force
+rm -f /tmp/dwibiascorrect_fsl.mif
+
+mrconvert /mnt/BIDS/sub-04/fmap/sub-04_dir-1_epi.nii.gz \
+    -json_import /mnt/BIDS/sub-04/fmap/sub-04_dir-1_epi.json /tmp/dir-1_epi.mif -force
+mrconvert /mnt/BIDS/sub-04/fmap/sub-04_dir-2_epi.nii.gz \
+    -json_import /mnt/BIDS/sub-04/fmap/sub-04_dir-2_epi.json /tmp/dir-2_epi.mif -force
+mrcat /tmp/dir-1_epi.mif /tmp/dir-2_epi.mif /tmp/seepi.mif -axis 3 -force
+rm -f /tmp/dir-1_epi.mif /tmp/dir-2_epi.mif
+dwifslpreproc /mnt/BIDS/sub-04/dwi/sub-04_dwi.nii.gz \
+    -fslgrad /mnt/BIDS/sub-04/dwi/sub-04_dwi.bvec /mnt/BIDS/sub-04/dwi/sub-04_dwi.bval /tmp/dwifslpreproc.mif \
+    -pe_dir ap -readout_time 0.1 -rpe_pair -se_epi /tmp/seepi.mif \
+    -eddyqc_all /tmp/eddyqc -force
+rm -rf /tmp/seepi.mif /tmp/dwifslpreproc.mif /tmp/eddyqc
+
+labelsgmfix /mnt/BIDS/sub-01/anat/aparc+aseg.mgz /mnt/BIDS/sub-01/anat/sub-01_T1w.nii.gz \
+    /mnt/labelsgmfix/FreeSurferColorLUT.txt /tmp/labelsgmfix.mif -force
+rm -f /tmp/labelsgmfix.mif

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -1,0 +1,155 @@
+ARG MAKE_JOBS="1"
+ARG DEBIAN_FRONTEND="noninteractive"
+
+FROM debian:buster as base
+FROM buildpack-deps:buster AS base-builder
+
+FROM base-builder as mrtrix3-builder
+
+# Git commit from which to build MRtrix3.
+ARG MRTRIX3_GIT_COMMITISH="master"
+# Command-line arguments for `./configure`
+ARG MRTRIX3_CONFIGURE_FLAGS=""
+# Command-line arguments for `./build`
+ARG MRTRIX3_BUILD_FLAGS=""
+
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        dc \
+        libeigen3-dev \
+        libfftw3-dev \
+        libgl1-mesa-dev \
+        libpng-dev \
+        libqt5opengl5-dev \
+        libqt5svg5-dev \
+        libtiff5-dev \
+        qt5-default \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone, build, and install MRtrix3.
+ARG MAKE_JOBS
+WORKDIR /opt/mrtrix3
+RUN git clone -b ${MRTRIX3_GIT_COMMITISH} --depth 1 https://github.com/MRtrix3/mrtrix3.git . \
+    && ./configure $MRTRIX3_CONFIGURE_FLAGS \
+    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS
+
+# Compile and  install ANTs.
+FROM base-builder as ants-builder
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        cmake \
+    && rm -rf /var/lib/apt/lists/*
+ARG MAKE_JOBS
+WORKDIR /src/ants
+RUN curl -fsSL https://github.com/ANTsX/ANTs/archive/v2.3.4.tar.gz \
+    | tar xz --strip-components 1 \
+    && mkdir build \
+    && cd build \
+    && cmake \
+        -DBUILD_ALL_ANTS_APPS:BOOL=OFF \
+        -DBUILD_SHARED_LIBS:BOOL=OFF \
+        -DBUILD_TESTING:BOOL=OFF \
+        -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DCMAKE_INSTALL_PREFIX:PATH=/opt/ants \
+        -DRUN_LONG_TESTS:BOOL=OFF \
+        -DRUN_SHORT_TESTS:BOOL=OFF \
+        --target=N4BiasFieldCorrection \
+        .. \
+    && make -j $MAKE_JOBS \
+    && cd ANTS-build \
+    && make install
+
+# Install FreeSurfer LUT
+FROM base-builder AS freesurfer-installer
+WORKDIR /opt/freesurfer
+RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+
+# Install FSL.
+FROM base-builder AS fsl-installer
+WORKDIR /opt/fsl
+RUN curl -fL -# --retry 5 https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.4-centos6_64.tar.gz \
+    | tar -xz --strip-components 1
+# Install fslpython in a separate layer to preserve the cache of the (long) download.
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        bc \
+        dc \
+        file \
+        libfontconfig1 \
+        libfreetype6 \
+        libgl1-mesa-dev \
+        libgl1-mesa-dri \
+        libglu1-mesa-dev \
+        libgomp1 \
+        libice6 \
+        libopenblas-base \
+        libxcursor1 \
+        libxft2 \
+        libxinerama1 \
+        libxrandr2 \
+        libxrender1 \
+        libxt6 \
+        sudo \
+        wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && bash /opt/fsl/etc/fslconf/fslpython_install.sh -f /opt/fsl
+
+FROM base as final
+COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3
+COPY --from=ants-builder /opt/ants /opt/ants
+COPY --from=fsl-installer /opt/fsl /opt/fsl
+COPY --from=freesurfer-installer /opt/freesurfer /opt/freesurfer
+
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        bc \
+        dc \
+        file \
+        libfontconfig1 \
+        libfreetype6 \
+        libgl1-mesa-dev \
+        libgl1-mesa-dri \
+        libglu1-mesa-dev \
+        libgomp1 \
+        libice6 \
+        libxcursor1 \
+        libxft2 \
+        libxinerama1 \
+        libxrandr2 \
+        libxrender1 \
+        libxt6 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        dc \
+        libeigen3-dev \
+        libfftw3-dev \
+        libgl1-mesa-dev \
+        libpng-dev \
+        libqt5opengl5-dev \
+        libqt5svg5-dev \
+        libtiff5-dev \
+        python3-distutils \
+        qt5-default \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+WORKDIR /work
+COPY . .
+
+ENV ANTSPATH=/opt/ants/bin \
+    FREESURFER_HOME=/opt/freesurfer \
+    FSLDIR=/opt/fsl \
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/fsl/lib:/opt/ants/lib:" \
+    PATH="/opt/ants/bin:/opt/fsl/bin:/opt/mrtrix3/bin:$PATH"
+
+ENV FSLOUTPUTTYPE=NIFTI_GZ \
+    FSLMULTIFILEQUIT=TRUE \
+    FSLTCLSH=$FSLDIR/bin/fsltclsh \
+    FSLWISH=$FSLDIR/bin/fslwish
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
My take at #4 

The Docker image for mrtrix3 can be built with `docker build -t mrtrix3 .`

The `full.Dockerfile` only needs to be used when updating the minified ants and fsl (and perhaps other) installations.

These Dockerfiles also make use of [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to greatly improve build times. Enable parallel building of build stages by setting the environment variable `DOCKER_BUILDKIT=1`.

@Lestropie - can you please take a look? Happy to answer any questions. Working version at `docker run --rm -it kaczmarj/mrtrix3:latest`