### PR TITLE
First version of Singularity recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Containers for *MRtrix3*
 
-Hosts Dockerfiles to build *MRtrix3* containers
+Hosts recipe files to build *MRtrix3* containers
 
-## Users: Run terminal command
+## Using Docker
+
+#### Run terminal command
 
 ```
 docker run --rm -it mrtrix3 <command>
@@ -10,7 +12,7 @@ docker run --rm -it mrtrix3 <command>
 
 If not built locally, `docker` will download the latest image from DockerHub.
 
-## Users: Run GUI
+#### Run GUI
 
 These instructions are for Linux.
 
@@ -20,7 +22,7 @@ docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY mrtrix3
 xhost -local:root  # Run this when finished.
 ```
 
-## Users: Locally build Docker image
+#### Locally build Docker image
 
 ```
 docker build --tag mrtrix3 .
@@ -28,6 +30,32 @@ docker build --tag mrtrix3 .
 
 Set `DOCKER_BUILDKIT=1` to build parts of the Docker image in parallel, which can speed up build time.
 Use `--build-arg MAKE_JOBS=4` to build *MRtrix3* with 4 processors (can substitute this with any number of processors > 0); if omitted, *MRtrix3* will be built using a single thread only.
+
+## Using Singularity
+
+#### Build container natively
+
+```
+singularity build MRtrix3_<version>.sif Singularity
+```
+
+#### Convert from Docker container
+
+```
+singularity build MRtrix3_<version>.sif docker://mrtrix/mrtrix3:<version>
+```
+
+#### Run terminal command
+
+```
+MRtrix3_<version>.sif <command>
+```
+
+#### Run GUI
+
+```
+singularity exec -B /run MRtrix3_<version>.sif mrview
+```
 
 -----
 

--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,67 @@
+Bootstrap: debootstrap
+OSVersion: focal
+Include: apt
+
+%environment
+
+# ACPCdetect
+    ARTHOME=/opt/art
+    export ARTHOME
+
+# ANTs
+    ANTSPATH=/opt/ants/bin
+    export ANTSPATH
+
+# FreeSurfer
+    FREESURFER_HOME=/opt/freesurfer
+    export FREESURFER_HOME
+
+# FSL
+    FSLDIR=/opt/fsl
+    FSLOUTPUTTYPE=NIFTI_GZ
+    FSLMULTIFILEQUIT=TRUE
+    FSLTCLSH=/opt/fsl/bin/fsltclsh
+    FSLWISH=/opt/fsl/bin/fslwish
+    export FSLDIR FSLOUTPUTTYPE FSLMULTIFILEQUIT FSLTCLSH FSLWISH
+    
+# All
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/bin:/.singularity.d/libs:/usr/lib:/opt/fsl/lib:$LD_LIBRARY_PATH"
+    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:/usr/local/cuda/bin:$PATH"
+    export LD_LIBRARY_PATH PATH
+
+%post
+# Non-interactive installation of packages
+    export DEBIAN_FRONTEND=noninteractive
+
+# Grab additional repositories
+    sed -i 's/main/main restricted universe multiverse/g' /etc/apt/sources.list
+    apt-get update && apt-get upgrade -y
+
+# Runtime requirements
+    apt-get update && apt-get install -y dc less libfftw3-bin liblapack3 libpng16-16 libtiff5 python3 python3-distutils zlib1g
+
+# Build requirements
+    apt-get update && apt-get install -y build-essential curl git libeigen3-dev libfftw3-dev libpng-dev libtiff5-dev wget zlib1g-dev 
+
+# Neuroimaging software / data dependencies
+    # Download minified ART ACPCdetect (V2.0).
+    mkdir -p /opt/art && curl -fsSL https://osf.io/73h5s/download | tar xz -C /opt/art --strip-components 1
+    # Download minified ANTs (2.3.4).
+    mkdir -p /opt/ants && curl -fsSL https://osf.io/3ad69/download | tar xz -C /opt/ants --strip-components 1
+    # Download FreeSurfer lookup table file (v7.1.1).
+    mkdir -p /opt/freesurfer && curl -fsSL -o /opt/freesurfer/FreeSurferColorLUT.txt https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+    # Download minified FSL (6.0.4).
+    mkdir -p /opt/fsl && curl -fsSL https://osf.io/xtpv5/download | tar xz -C /opt/fsl --strip-components 1
+
+# Use Python3 for anything requesting Python, since Python2 is not installed
+    ln -s /usr/bin/python3 /usr/bin/python
+
+# MRtrix3 setup
+    git clone -b master --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
+    cd /opt/mrtrix3 && ./configure -nogui && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
+
+# apt cleanup to recover as much space as possible
+    apt-get remove -y build-essential curl git libeigen3-dev libfftw3-dev libpng-dev libtiff5-dev wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+%runscript
+    exec /usr/bin/bash "$@"

--- a/Singularity
+++ b/Singularity
@@ -52,7 +52,7 @@ Include: apt
     # Download FreeSurfer lookup table file (v7.1.1).
     mkdir -p /opt/freesurfer && curl -fsSL -o /opt/freesurfer/FreeSurferColorLUT.txt https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
     # Download minified FSL (6.0.4).
-    mkdir -p /opt/fsl && curl -fsSL https://osf.io/xtpv5/download | tar xz -C /opt/fsl --strip-components 1
+    mkdir -p /opt/fsl && curl -fsSL https://osf.io/dv258/download | tar xz -C /opt/fsl --strip-components 1
 
 # Use Python3 for anything requesting Python, since Python2 is not installed
     ln -s /usr/bin/python3 /usr/bin/python

--- a/Singularity
+++ b/Singularity
@@ -1,5 +1,6 @@
 Bootstrap: debootstrap
 OSVersion: focal
+MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 Include: apt
 
 %environment

--- a/Singularity
+++ b/Singularity
@@ -39,10 +39,10 @@ Include: apt
     apt-get update && apt-get upgrade -y
 
 # Runtime requirements
-    apt-get update && apt-get install -y dc less libfftw3-bin liblapack3 libpng16-16 libtiff5 python3 python3-distutils zlib1g
+    apt-get update && apt-get install -y --no-install-recommends dc less libfftw3-bin liblapack3 libpng16-16 libqt5network5 libqt5widgets5 libtiff5 python3 python3-distutils zlib1g
 
 # Build requirements
-    apt-get update && apt-get install -y build-essential curl git libeigen3-dev libfftw3-dev libpng-dev libtiff5-dev wget zlib1g-dev 
+    apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev
 
 # Neuroimaging software / data dependencies
     # Download minified ART ACPCdetect (V2.0).
@@ -59,10 +59,10 @@ Include: apt
 
 # MRtrix3 setup
     git clone -b master --depth 1 https://github.com/MRtrix3/mrtrix3.git /opt/mrtrix3
-    cd /opt/mrtrix3 && ./configure -nogui && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
+    cd /opt/mrtrix3 && ./configure && ./build -persistent -nopaginate && rm -rf testing/ tmp/ && cd ../../
 
 # apt cleanup to recover as much space as possible
-    apt-get remove -y build-essential curl git libeigen3-dev libfftw3-dev libpng-dev libtiff5-dev wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get remove -y build-essential ca-certificates curl git libeigen3-dev libfftw3-dev libgl1-mesa-dev libpng-dev libqt5opengl5-dev libqt5svg5-dev libtiff5-dev qt5-qmake qtbase5-dev-tools wget zlib1g-dev && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 %runscript
     exec /usr/bin/bash "$@"


### PR DESCRIPTION
Addresses #17.

This is working thus far for me for terminal commands; have not yet made an attempt at getting GUI working.

Note that `focal` was required over `bionic` due to the pre-compiled version of `N4BiasFieldCorrection` requiring `GCC >= 2.28`, but the package repositories for the base `bionic` image not providing beyond `2.27`.

While with this addition a Singularity image built from the Docker image will be *somehow* different from a SIngularity image that is instead built from this recipe, I don't think the differences should be consequential?