### PR TITLE
Fixes to container dependencies following 3.0.3 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN curl -fsSL https://github.com/ANTsX/ANTs/archive/v2.3.4.tar.gz \
         .. \
     && make -j $MAKE_JOBS \
     && cd ANTS-build \
-    && make install
+    && make install \
+    && cp /src/ants/ANTSCopyright.txt /opt/ants/
 
 # Install FreeSurfer LUT
 FROM base-builder AS freesurfer-installer
@@ -114,6 +115,7 @@ RUN apt-get -qq update \
         libtiff5 \
         pigz \
         python3-distutils \
+        tree \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/d
 # Install FSL.
 FROM base-builder AS fsl-installer
 WORKDIR /opt/fsl
+COPY FSL_source.txt source.txt
 RUN curl -fL -# --retry 5 https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.4-centos6_64.tar.gz \
     | tar -xz --strip-components 1
 # Install fslpython in a separate layer to preserve the cache of the (long) download.
@@ -115,7 +116,6 @@ RUN apt-get -qq update \
         libtiff5 \
         pigz \
         python3-distutils \
-        tree \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3

--- a/FSL_source.txt
+++ b/FSL_source.txt
@@ -1,0 +1,1 @@
+https://git.fmrib.ox.ac.uk/fsl

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ These files should only need to be updated if:
     mkdir -p tarballs
     docker run --rm -itd --workdir /opt --name mrtrix3 \
         --volume $(pwd)/tarballs:/output mrtrix3:minified bash
-    docker exec mrtrix3 bash -c "tar c art | pigz -9 > /output/acpcdetect_<version>.tar.gz"
-    docker exec mrtrix3 bash -c "tar c ants | pigz -9 > /output/ants_<version>.tar.gz"
-    docker exec mrtrix3 bash -c "tar c fsl | pigz -9 > /output/fsl_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find art/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/acpcdetect_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find ants/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/ants_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find fsl/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/fsl_<version>.tar.gz"
     docker stop mrtrix3
     ```
 

--- a/cmds-to-minify.sh
+++ b/cmds-to-minify.sh
@@ -50,17 +50,10 @@ rm -f /tmp/labelsgmfix.mif
 
 cat /opt/ants/ANTSCopyright.txt
 
-##################################################################
-# Capture FSL source code (required by license for distribution) #
-##################################################################
+############################
+# Capture FSL sidecar data #
+############################
 
-fsl_include_subdirs="basisfield bet2 fast4 first first_lib flirt fnirt fslio fslvtkio miscmaths mm newimage niftiio shapeModel topup utils warpfns znzlib"
-for subdir in $fsl_include_subdirs; do
-    tree ${FSLDIR}/include/${subdir}
-done
-fsl_src_subdirs="basisfield bet2 fast4 first first_lib flirt fnirt fslio fslvtkio libmeshutils meshclass miscmaths mm newimage niftiio shapeModel topup utils warpfns znzlib"
-for subdir in $fsl_src_subdirs; do
-    tree ${FSLDIR}/src/${subdir}
-done
+cat ${FSLDIR}/source.txt
 cat ${FSLDIR}/LICENCE
 cat ${FSLDIR}/etc/fslversion

--- a/cmds-to-minify.sh
+++ b/cmds-to-minify.sh
@@ -9,7 +9,10 @@ if [ ! -d /mnt/BIDS ]; then
     exit 1
 fi
 
-# Run tests to capture external software dependencies
+#######################################################
+# Run tests to capture external software dependencies #
+#######################################################
+
 5ttgen fsl /mnt/BIDS/sub-01/anat/sub-01_T1w.nii.gz /tmp/5ttgen_fsl_default.mif -force
 5ttgen fsl /mnt/BIDS/sub-01/anat/sub-01_T1w.nii.gz /tmp/5ttgen_fsl_nocrop.mif -nocrop -force
 rm -f /tmp/5ttgen_fsl_default.mif /tmp/5ttgen_fsl_nocrop.mif
@@ -34,10 +37,30 @@ rm -f /tmp/dir-1_epi.mif /tmp/dir-2_epi.mif
 dwifslpreproc /mnt/BIDS/sub-04/dwi/sub-04_dwi.nii.gz \
     -fslgrad /mnt/BIDS/sub-04/dwi/sub-04_dwi.bvec /mnt/BIDS/sub-04/dwi/sub-04_dwi.bval /tmp/dwifslpreproc.mif \
     -pe_dir ap -readout_time 0.1 -rpe_pair -se_epi /tmp/seepi.mif \
-    -eddyqc_all /tmp/eddyqc -force
+    -eddyqc_all /tmp/eddyqc -eddy_options " --cnr_maps" -force
 rm -rf /tmp/seepi.mif /tmp/dwifslpreproc.mif /tmp/eddyqc
 
 labelsgmfix /mnt/BIDS/sub-01/anat/aparc+aseg.mgz /mnt/BIDS/sub-01/anat/sub-01_T1w.nii.gz \
     /mnt/labelsgmfix/FreeSurferColorLUT.txt /tmp/labelsgmfix.mif -sgm_amyg_hipp -force
 rm -f /tmp/labelsgmfix.mif
 
+###########################################################################
+# Capture ANTs license file (required by license for binary distribution) #
+###########################################################################
+
+cat /opt/ants/ANTSCopyright.txt
+
+##################################################################
+# Capture FSL source code (required by license for distribution) #
+##################################################################
+
+fsl_include_subdirs="basisfield bet2 fast4 first first_lib flirt fnirt fslio fslvtkio miscmaths mm newimage niftiio shapeModel topup utils warpfns znzlib"
+for subdir in $fsl_include_subdirs; do
+    tree ${FSLDIR}/include/${subdir}
+done
+fsl_src_subdirs="basisfield bet2 fast4 first first_lib flirt fnirt fslio fslvtkio libmeshutils meshclass miscmaths mm newimage niftiio shapeModel topup utils warpfns znzlib"
+for subdir in $fsl_src_subdirs; do
+    tree ${FSLDIR}/src/${subdir}
+done
+cat ${FSLDIR}/LICENCE
+cat ${FSLDIR}/etc/fslversion


### PR DESCRIPTION
Details in 2a9c588.
Priority is to not violate FSL license requirements.
This PR only updates the files responsible for constructing the minified dependency downloads. Those updated files are now on OSF, and a PR on MRtrix3/mrtrix3 will be necessary to have the container recipes download those updated dependencies.
Also note that these updated dependencies do *not* include those additional dependencies that will be necessary to support the new Python implementation of `dwi2mask` (MRtrix3/mrtrix3#2197) that will be included as of version `3.1.0`; that will be done in a separate update.