### PR TITLE
README: Install Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,29 @@ These files should only need to be updated if:
 -   An *MRtrix3* update introduces a new feature that invokes some new external software tool not previously utilised;
 -   A requisite update occurs in one of these external softwares.
 
-1.  Install the `docker` and `neurodocker` Python packages.
+1.  Install Docker however it must be installed for your particular
+    operating system / Linux flavour.
+
+2.  Install the `docker` and `neurodocker` Python packages.
 
     ````
     pip install docker neurodocker
     ````
 
-2.  Download the ART ACPCdetect tool from NITRC into the working directory.
+3.  Download the ART ACPCdetect tool from NITRC into the working directory.
 
     This cannot be downloaded directly via e.g. `wget`, as it requires logging in to NITRC; instead, visit the following link with a web browser:
     [`https://www.nitrc.org/frs/download.php/10595/acpcdetect_v2.0_LinuxCentOS6.7.tar.gz`](https://www.nitrc.org/frs/download.php/10595/acpcdetect_v2.0_LinuxCentOS6.7.tar.gz)
 
-3. Download test data necessary for minification process.
+4. Download test data necessary for minification process.
 
     ```
     curl -fL -# https://github.com/MRtrix3/script_test_data/archive/master.tar.gz | tar xz
     ```
 
-4. Update file `minify.Dockerfile` to install the desired versions of external software packages.
+5. Update file `minify.Dockerfile` to install the desired versions of external software packages.
 
-5. Build Docker image for `neurodocker-minify`, with complete installations of external packages.
+6. Build Docker image for `neurodocker-minify`, with complete installations of external packages.
 
     ```
     DOCKER_BUILDKIT=1 docker build --tag mrtrix3:minify --build-arg MAKE_JOBS=4 .
@@ -47,7 +50,7 @@ These files should only need to be updated if:
     The `MAKE_JOBS` argument controls how many cores are used for compilation of ANTs and *MRtrix3*.
     If BuildKit is utilised, do not specify all of the available threads; specify half or fewer, so that threads are not unnecessarily split across jobs and RAM usage is not excessive.
 
-6. Create a minified version of the Docker image.
+7. Create a minified version of the Docker image.
 
     ```
     docker run --rm -itd --name mrtrix3 --security-opt=seccomp:unconfined --volume $(pwd)/script_test_data-master:/mnt mrtrix3:minify
@@ -56,7 +59,7 @@ These files should only need to be updated if:
     docker stop mrtrix3
     ```
 
-7. Generate tarballs for each of the utilised dependencies.
+8. Generate tarballs for each of the utilised dependencies.
 
     ```
     mkdir -p tarballs
@@ -70,8 +73,7 @@ These files should only need to be updated if:
 
     For each tarball, manually replace text "`<version>`" with the version number of that particular software that was installed in the container.
 
-7.  Upload these files to [OSF](https://osf.io/nfx85/).
+9.  Upload these files to [OSF](https://osf.io/nfx85/).
 
 Files `Dockerfile` and `Singularity` in the [main *MRtrix3* repository](https://www.github.com/MRtrix3/mrtrix3) can then be modified to download the desired versions of external software packages.
 As OSF file download links do not contain file names, which would otherwise indicate the version of each software to be downloaded, please ensure that comments within that file are updated to indicate the version of that software within the tarball.
-


### PR DESCRIPTION
Add explicit instruction to install Docker, as distinct from the Python `docker` package.