### PR TITLE
New dependencies for Python-based dwi2mask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG MAKE_JOBS="1"
 ARG DEBIAN_FRONTEND="noninteractive"
 
-FROM debian:buster as base
-FROM buildpack-deps:buster AS base-builder
+FROM debian:bullseye-backports AS base
+FROM buildpack-deps:bullseye AS base-builder
 
 FROM base-builder as mrtrix3-builder
 
 # Git commitish from which to build MRtrix3.
-ARG MRTRIX3_GIT_COMMITISH="master"
+ARG MRTRIX3_GIT_COMMITISH="dev"
 # Command-line arguments for `./configure`
 ARG MRTRIX3_CONFIGURE_FLAGS="-nogui"
 # Command-line arguments for `./build`
@@ -19,6 +19,7 @@ RUN apt-get -qq update \
         libfftw3-dev \
         libpng-dev \
         libtiff5-dev \
+        python-is-python3 \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -26,15 +27,24 @@ RUN apt-get -qq update \
 ARG MAKE_JOBS
 WORKDIR /opt/mrtrix3
 RUN git clone -b ${MRTRIX3_GIT_COMMITISH} --depth 1 https://github.com/MRtrix3/mrtrix3.git . \
-    && ./configure $MRTRIX3_CONFIGURE_FLAGS \
-    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS \
-    && rm -rf testing/ tmp/
+    && ./configure $MRTRIX3_CONFIGURE_FLAGS  \
+    && NUMBER_OF_PROCESSORS=$MAKE_JOBS ./build $MRTRIX3_BUILD_FLAGS
+
+# Install AFNI
+FROM base-builder AS afni-builder
+WORKDIR /opt/afni
+RUN apt-get -qq update \
+    && apt-get install -yq --no-install-recommends \
+        rsync \
+        tcsh
+RUN curl -O https://afni.nimh.nih.gov/pub/dist/bin/misc/@update.afni.binaries
+RUN tcsh @update.afni.binaries -package linux_ubuntu_16_64 -bindir /opt/afni
 
 # Install ART ACPCdetect.
-from base-builder as acpcdetect-builder
+FROM base-builder as acpcdetect-builder
 WORKDIR /opt/art
-COPY acpcdetect_v2.0_LinuxCentOS6.7.tar.gz /opt/art/acpcdetect_v2.0_LinuxCentOS6.7.tar.gz
-RUN tar -xf acpcdetect_v2.0_LinuxCentOS6.7.tar.gz
+COPY acpcdetect_V2.1_LinuxCentOS6.7.tar.gz /opt/art/acpcdetect_V2.1_LinuxCentOS6.7.tar.gz
+RUN tar -xf acpcdetect_V2.1_LinuxCentOS6.7.tar.gz
 
 # Compile and install ANTs.
 FROM base-builder as ants-builder
@@ -45,29 +55,28 @@ RUN apt-get -qq update \
     && rm -rf /var/lib/apt/lists/*
 ARG MAKE_JOBS
 WORKDIR /src/ants
-RUN curl -fsSL https://github.com/ANTsX/ANTs/archive/v2.3.4.tar.gz \
+RUN curl -fsSL https://github.com/ANTsX/ANTs/archive/v2.4.3.tar.gz \
     | tar xz --strip-components 1 \
     && mkdir build \
     && cd build \
     && cmake \
-        -DBUILD_ALL_ANTS_APPS:BOOL=OFF \
         -DBUILD_SHARED_LIBS:BOOL=OFF \
         -DBUILD_TESTING:BOOL=OFF \
         -DCMAKE_BUILD_TYPE:STRING=Release \
         -DCMAKE_INSTALL_PREFIX:PATH=/opt/ants \
         -DRUN_LONG_TESTS:BOOL=OFF \
         -DRUN_SHORT_TESTS:BOOL=OFF \
-        --target=N4BiasFieldCorrection \
         .. \
     && make -j $MAKE_JOBS \
     && cd ANTS-build \
     && make install \
-    && cp /src/ants/ANTSCopyright.txt /opt/ants/
+    && cp /src/ants/ANTSCopyright.txt /opt/ants/ANTSCopyright.txt
 
-# Install FreeSurfer LUT
+# Install FreeSurfer
 FROM base-builder AS freesurfer-installer
 WORKDIR /opt/freesurfer
-RUN curl -fsSLO https://raw.githubusercontent.com/freesurfer/freesurfer/v7.1.1/distribution/FreeSurferColorLUT.txt
+RUN curl -fsSL https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/7.3.2/freesurfer-linux-ubuntu20_amd64-7.3.2.tar.gz \
+    | tar xz --strip-components 1
 
 # Install FSL.
 FROM base-builder AS fsl-installer
@@ -95,11 +104,24 @@ RUN apt-get -qq update \
         libxrandr2 \
         libxrender1 \
         libxt6 \
+        python2.7 \
         sudo \
         wget \
     && rm -rf /var/lib/apt/lists/* \
     && bash /opt/fsl/etc/fslconf/fslpython_install.sh -f /opt/fsl
 
+# Install HD-BET
+FROM base-builder as hdbet-installer
+WORKDIR /opt/hdbet
+RUN git clone https://github.com/MIC-DKFZ/HD-BET .
+
+# Obtain MNI template data to be used in executing exemplar commands
+FROM base-builder as mni-installer
+WORKDIR /opt/mni
+RUN wget http://www.bic.mni.mcgill.ca/~vfonov/icbm/2009/mni_icbm152_nlin_asym_09c_nifti.zip \
+    && unzip -j mni_icbm152_nlin_asym_09c_nifti.zip
+
+# Build final image
 FROM base as final
 
 RUN apt-get -qq update \
@@ -116,17 +138,23 @@ RUN apt-get -qq update \
         libtiff5 \
         pigz \
         python3-distutils \
+        python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=mrtrix3-builder /opt/mrtrix3 /opt/mrtrix3
+COPY --from=afni-builder /opt/afni /opt/afni
 COPY --from=acpcdetect-builder /opt/art /opt/art
 COPY --from=ants-builder /opt/ants /opt/ants
 COPY --from=fsl-installer /opt/fsl /opt/fsl
 COPY --from=freesurfer-installer /opt/freesurfer /opt/freesurfer
+COPY --from=hdbet-installer /opt/hdbet /opt/hdbet
+COPY --from=mni-installer /opt/mni /opt/mni
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN cd /opt/hdbet && pip install -e .
 
 COPY cmds-to-minify.sh /cmds-to-minify.sh
+COPY mrtrix.conf /etc/mrtrix.conf
 WORKDIR /
 
 ENV ANTSPATH=/opt/ants/bin \
@@ -138,7 +166,7 @@ ENV ANTSPATH=/opt/ants/bin \
     FSLTCLSH=/opt/fsl/bin/fsltclsh \
     FSLWISH=/opt/fsl/bin/fslwish \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/fsl/lib:/opt/ants/lib:" \
-    PATH="/opt/mrtrix3/bin:/opt/ants/bin:/opt/art/bin:/opt/fsl/bin:$PATH"
+    PATH="/opt/mrtrix3/bin:/opt/afni:/opt/ants/bin:/opt/art/bin:/opt/freesurfer/bin:/opt/fsl/bin:/opt/hdbet/HD_BET:$PATH"
 
 ENTRYPOINT ["/bin/bash"]
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ These files should only need to be updated if:
     docker run --rm -itd --workdir /opt --name mrtrix3 \
         --volume $(pwd)/tarballs:/output mrtrix3:minified bash
     docker exec mrtrix3 bash -c "find art/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/acpcdetect_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find afni/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/afni_<version>.tar.gz"
     docker exec mrtrix3 bash -c "find ants/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/ants_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find freesurfer/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/freesurfer_<version>.tar.gz"
     docker exec mrtrix3 bash -c "find fsl/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/fsl_<version>.tar.gz"
+    docker exec mrtrix3 bash -c "find hdbet/ -type f | tar c --files-from=/dev/stdin | pigz -9 > /output/hdbet_<version>.tar.gz"
     docker stop mrtrix3
     ```
 

--- a/cmds-to-minify.sh
+++ b/cmds-to-minify.sh
@@ -20,6 +20,43 @@ rm -f /tmp/5ttgen_fsl_default.mif /tmp/5ttgen_fsl_nocrop.mif
 5ttgen hsvs /mnt/freesurfer/sub-01 /tmp/5ttgen_hsvs.mif -force
 rm -f /tmp/5ttgen_hsvs.mif
 
+# For dwi2mask, don't use consensus, since that will happily skip specific algorithms
+#   if there is some error in their execution; here we want to make sure that
+#   all are successful and all dependencies are present and captured
+
+dwi2mask 3dautomask /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_3dautomask.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval -force
+rm -f /tmp/dwi2mask_3dautomask.mif
+
+dwi2mask ants /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_ants.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval -force
+rm -f /tmp/dwi2mask_ants.mif
+
+# TODO Need template for dwi2mask b02template
+dwi2mask b02template /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_b02template_antsquick.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval \
+    -software antsquick -force
+dwi2mask b02template /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_b02template_antsfull.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval \
+    -software antsfull -force
+dwi2mask b02template /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_b02template_fsl.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval \
+    -software fsl -force
+rm -f /tmp/dwi2mask_b02template_antsquick.mif /tmp/dwi2mask_b02template_antsfull.mif /tmp/dwi2mask_b02template_fsl.mif
+
+dwi2mask fslbet /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_fslbet.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval -force
+rm -f /tmp/dwi2mask_fslbet.mif
+
+dwi2mask hdbet /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_hdbet.mif -nogpu \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval -force
+rm -f /tmp/dwi2mask_hdbet.mif
+
+# TODO Capture both models, with and without CSF
+dwi2mask synthstrip /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz /tmp/dwi2mask_synthstrip.mif \
+    -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval -force
+rm -f /tmp/dwi2mask_synthstrip.mif
+
 dwibiascorrect ants /mnt/BIDS/sub-01/dwi/sub-01_dwi.nii.gz \
     -fslgrad /mnt/BIDS/sub-01/dwi/sub-01_dwi.bvec /mnt/BIDS/sub-01/dwi/sub-01_dwi.bval /tmp/dwibiascorrect_ants.mif -force
 rm -f /tmp/dwibiascorrect_ants.mif
@@ -44,16 +81,32 @@ labelsgmfix /mnt/BIDS/sub-01/anat/aparc+aseg.mgz /mnt/BIDS/sub-01/anat/sub-01_T1
     /mnt/labelsgmfix/FreeSurferColorLUT.txt /tmp/labelsgmfix.mif -sgm_amyg_hipp -force
 rm -f /tmp/labelsgmfix.mif
 
+#############################
+# Capture AFNI sidecar data #
+#############################
+cat /opt/afni/AFNI_version.txt
+cat /opt/afni/README.copyright
+
 ###########################################################################
 # Capture ANTs license file (required by license for binary distribution) #
 ###########################################################################
-
 cat /opt/ants/ANTSCopyright.txt
+
+###################################
+# Capture FreeSurfer sidecar data #
+###################################
+cat /opt/freesurfer/build-stamp.txt
+# TODO Find out if this is sufficient for minify to capture these
+ls -la /opt/freesurfer/docs
 
 ############################
 # Capture FSL sidecar data #
 ############################
-
 cat ${FSLDIR}/source.txt
 cat ${FSLDIR}/LICENCE
 cat ${FSLDIR}/etc/fslversion
+
+##########################
+# Capture HD-BET license #
+##########################
+cat /opt/hdbet/LICENSE

--- a/mrtrix.conf
+++ b/mrtrix.conf
@@ -1,0 +1,2 @@
+Dwi2maskTemplateImage: /opt/mni/mni_icbm152_t2_tal_nlin_asym_09c.nii
+Dwi2maskTemplateMask: /opt/mni/mni_icbm152_t1_tal_nlin_asym_09c_mask.nii


### PR DESCRIPTION
I had this content sitting on my drive for https://github.com/MRtrix3/mrtrix3/issues/2529, and had to get it out of the way so that I could start working on https://github.com/MRtrix3/mrtrix3/issues/2921.

This needs to remain as a draft PR; only upon tag of `3.1.0` should this be going to `master`.